### PR TITLE
feat: add QueryResponse for richer query responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- New `query` response object `QueryResponse` contains information about the sources on which the response is based on. You can now extract the titles as well as the document chunks from the response.
+
+### Changed
+
+- Changed the return type of the query method to return a `QueryResponse` object instead of an optional string. To get the response string as before, call `response.content` on the query response.
+
 ## [0.0.8] - 2024-02-04
 
 ### Fixed

--- a/docs/source/contents/api_reference.rst
+++ b/docs/source/contents/api_reference.rst
@@ -48,6 +48,9 @@ Models
 
 .. automodule:: ragcore.models.document_model
     :members:
+
+.. automodule:: ragcore.models.app_model
+    :members:
     
 .. automodule:: ragcore.models.document_loader_model
     :members:

--- a/docs/source/contents/first_app.rst
+++ b/docs/source/contents/first_app.rst
@@ -49,19 +49,23 @@ Finally, in the ``app.py`` file, we can implement our application using the comp
 
 .. code-block:: python
 
-    from ragcore import RAGCore
+  from ragcore import RAGCore
 
-    app = RAGCore() # pass config=<path-to-config.yaml> if not in root
+  app = RAGCore() # pass config=<path-to-config.yaml> if not in root
 
-    # Upload a document "My_Book.pdf"
-    app.add(path="My_Book.pdf")
+  # Upload a document "My_Book.pdf"
+  app.add(path="My_Book.pdf")
 
-    # Now you can ask questions
-    answer = app.query(query="What did the elk say?")
+  # Now you can ask questions
+  answer = app.query(query="What did the elk say?")
 
-    print(answer)
+  print(answer.content)
 
-    # You can delete by title
-    app.delete(title="My_Book")
+  # List the document's title and content on which the answer is based
+  for doc in answer.documents:
+    print(doc.title, " | ", doc.content)
+
+  # You can delete by title
+  app.delete(title="My_Book")
 
 And that's it! For more details on configuration options, please refer to the :ref:`configuration` section.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,20 +18,24 @@ Once you have selected the components that suit your needs with the config file,
 
 .. code-block:: python
 
-    from ragcore import RAGCore
+   from ragcore import RAGCore
 
-    app = RAGCore() # pass config=<path-to-config.yaml> if not in root
+   app = RAGCore() # pass config=<path-to-config.yaml> if not in root
 
-    # Upload a document "My_Book.pdf"
-    app.add(path="My_Book.pdf")
+   # Upload a document "My_Book.pdf"
+   app.add(path="My_Book.pdf")
 
-    # Now you can ask questions
-    answer = app.query(query="What did the elk say?")
+   # Now you can ask questions
+   answer = app.query(query="What did the elk say?")
 
-    print(answer)
+   print(answer.content)
 
-    # You can delete by title
-    app.delete(title="My_Book")
+   # List the document's title and content on which the answer is based
+   for doc in answer.documents:
+      print(doc.title, " | ", doc.content)
+
+   # You can delete by title
+   app.delete(title="My_Book")
 
 
 .. toctree::

--- a/ragcore/app/base_app.py
+++ b/ragcore/app/base_app.py
@@ -1,7 +1,8 @@
 from abc import ABCMeta, abstractmethod
 import logging
 from logging import Logger
-from typing import Optional
+
+from ragcore.models.app_model import QueryResponse
 
 LOGGER_FILENAME = "app.log"
 
@@ -55,7 +56,7 @@ class AbstractApp(metaclass=ABCMeta):
         return logger
 
     @abstractmethod
-    def query(self, query: str) -> Optional[str]:
+    def query(self, query: str) -> QueryResponse:
         """Runs a query against a database."""
 
     @abstractmethod

--- a/ragcore/cli.py
+++ b/ragcore/cli.py
@@ -1,8 +1,8 @@
 import argparse
-from typing import Optional
 
 from ragcore.shared.constants import AppConstants
 from ragcore.app import RAGCore
+from ragcore.models.app_model import QueryResponse
 
 
 SEPARATOR_LINE = "--" * 64
@@ -28,19 +28,21 @@ def run_app(app) -> None:
             title = input("Enter title to remove from database: ")
             app.delete(title=title)
         else:
-            response: Optional[str] = app.query(query=user_input)
-            if not response:
+            response: QueryResponse = app.query(query=user_input)
+            if not response.content:
                 continue
-            print(f"\n{SEPARATOR_LINE}\n{response}\n{SEPARATOR_LINE}\n")
+            print(f"\n{SEPARATOR_LINE}\n{response.content}\n{SEPARATOR_LINE}\n")
 
 
 def entrypoint():
     arguments: dict[str, str] = _parse_args()
     cli_app = RAGCore(
         config=arguments.get(AppConstants.KEY_CONFIGURATION_PATH),
-        log_level=LOGGER_LEVEL_DEBUG
-        if arguments.get(AppConstants.KEY_LOGGER_FLAG)
-        else LOGGER_LEVEL_WARN,
+        log_level=(
+            LOGGER_LEVEL_DEBUG
+            if arguments.get(AppConstants.KEY_LOGGER_FLAG)
+            else LOGGER_LEVEL_WARN
+        ),
     )
     run_app(cli_app)
 

--- a/ragcore/dto/document_dto.py
+++ b/ragcore/dto/document_dto.py
@@ -11,7 +11,7 @@ class DocumentDTO:
         .. code-block:: python
 
             # Instantiate a DTO
-            dto = DocumentDTO(content="This is my text", metadata={"title": "Great text", "page": "1"})
+            dto = DocumentDTO(content="This is my text", title="Great text", metadata={"title": "Great text", "page": "1"})
 
             # Now you can create a ragcore document
             doc = dto.to_ragcore()
@@ -19,17 +19,20 @@ class DocumentDTO:
     Attributes:
         content: A string for the page content.
 
+        title: The title of the document as a string.
+
         metadata: A mapping for metadata.
 
     """
 
-    def __init__(self, content: str, metadata: Mapping[str, Any]):
+    def __init__(self, content: str, title: str, metadata: Mapping[str, Any]):
         self.content = content
+        self.title = title
         self.metadata = metadata
 
     def to_ragcore(self):
         """Converts to a RAG Core document type."""
-        return Document(content=self.content, metadata=self.metadata)
+        return Document(content=self.content, title=self.title, metadata=self.metadata)
 
     def to_langchain(self):
         """Converts to a LangChain document type."""
@@ -49,7 +52,9 @@ class DocumentDTO:
         documents = []
         for lang_document in lang_documents:
             doc_dto = DocumentDTO(
-                content=lang_document.page_content, metadata=lang_document.metadata
+                content=lang_document.page_content,
+                title=lang_document.metadata.get("title", ""),
+                metadata=lang_document.metadata,
             )
             documents.append(doc_dto.to_ragcore())
         return documents

--- a/ragcore/models/app_model.py
+++ b/ragcore/models/app_model.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from ragcore.models.document_model import Document
+
+
+@dataclass
+class QueryResponse:
+    """Model for query responses.
+
+    Attributes:
+        content: String with the response, None if no response could be generated.
+
+        documents: Sequence of documents on which the response is based on. Empty list if response is None.
+
+    """
+
+    content: Optional[str]
+    documents: Sequence[Optional[Document]]

--- a/ragcore/models/database_model.py
+++ b/ragcore/models/database_model.py
@@ -206,7 +206,13 @@ class ChromaDatabase(BaseLocalVectorDatabaseModel):
 
         for doc, metadata in zip(response_docs, response_metadata):
             metadata_mapping: Mapping[str, Any] = metadata
-            documents.append(Document(content=doc, metadata=metadata_mapping))
+            documents.append(
+                Document(
+                    content=doc,
+                    title=str(metadata.get("title", "")),
+                    metadata=metadata_mapping,
+                )
+            )
 
         return documents
 

--- a/ragcore/models/document_model.py
+++ b/ragcore/models/document_model.py
@@ -9,8 +9,11 @@ class Document:
     Attributes:
         content: The content of document, as string.
 
+        title: The title of the document.
+
         metadata: A mapping for the metadata.
     """
 
     content: str
+    title: str
     metadata: Mapping[str, Any]

--- a/ragcore/services/database_service.py
+++ b/ragcore/services/database_service.py
@@ -144,7 +144,8 @@ class DatabaseService:
 
         # Add the documents.
         self.logger.info(
-            f"Trying to add {len(documents)} documents to database at `{self.base_path if self.base_path else '' + '/' + self.name if self.name else ''}`..."
+            f"Trying to add {len(documents)} documents to database at "
+            f"`{self.base_path if self.base_path else '' + '/' + self.name if self.name else ''}`..."
         )
 
         if self.database.add_documents(documents=documents):

--- a/ragcore/services/text_splitter_service.py
+++ b/ragcore/services/text_splitter_service.py
@@ -33,7 +33,9 @@ class TextSplitterService:
 
         for document in documents:
             document_dto = DocumentDTO(
-                content=document.content, metadata=document.metadata
+                content=document.content,
+                title=document.title,
+                metadata=document.metadata,
             )
             documents_lang.append(document_dto.to_langchain())
 
@@ -42,7 +44,9 @@ class TextSplitterService:
         splits = []
         for split_lang in splits_lang:
             document_dto = DocumentDTO(
-                content=split_lang.page_content, metadata=split_lang.metadata
+                content=split_lang.page_content,
+                title=split_lang.metadata.get("title", ""),
+                metadata=split_lang.metadata,
             )
             splits.append(document_dto.to_ragcore())
 

--- a/tests/unit/dto/test_document_dto.py
+++ b/tests/unit/dto/test_document_dto.py
@@ -7,7 +7,9 @@ class TestDocumentDTO(RAGCoreTestSetup):
         docs = []
         for lang_document in mock_lang_documents:
             dto = DocumentDTO(
-                content=lang_document.page_content, metadata=lang_document.metadata
+                content=lang_document.page_content,
+                title=lang_document.metadata.get("title", ""),
+                metadata=lang_document.metadata,
             )
             doc = dto.to_ragcore()
             docs.append(doc)
@@ -19,7 +21,11 @@ class TestDocumentDTO(RAGCoreTestSetup):
     def test_to_langchain(self, mock_documents):
         docs = []
         for document in mock_documents:
-            dto = DocumentDTO(content=document.content, metadata=document.metadata)
+            dto = DocumentDTO(
+                content=document.content,
+                title=document.title,
+                metadata=document.metadata,
+            )
             doc = dto.to_langchain()
             docs.append(doc)
 

--- a/tests/unit/services/__init__.py
+++ b/tests/unit/services/__init__.py
@@ -10,10 +10,12 @@ class RAGCoreTestSetup:
     def mock_pages(self):
         page1 = Document(
             content="Hello, this is the first page.",
+            title="file",
             metadata={"source": "some_path/file.pdf", "page": 1},
         )
         page2 = Document(
             content="This is the second page.",
+            title="file",
             metadata={"source": "some_path/file.pdf", "page": 2},
         )
         return [page1, page2]
@@ -24,11 +26,13 @@ class RAGCoreTestSetup:
             content="""Very useful text. It also contains a new sentence.
 
             And, as we can see here, even a separate paragraph! Life is crazy.""",
+            title="Greatest book",
             metadata={"page": 1, "title": "Greatest book"},
         )
         page2 = Document(
             content="""Another day, another sentence.
                             We need them all for testing. Let's go!!!""",
+            title="Greatest book",
             metadata={"page": 2, "title": "Greatest book"},
         )
         return [page1, page2]
@@ -39,11 +43,13 @@ class RAGCoreTestSetup:
             content="""Very useful text. It also contains a new sentence.
 
             And, as we can see here, even a separate paragraph! Life is crazy.""",
+            title="Greatest book",
             metadata={},
         )
         page2 = Document(
             content="""Another day, another sentence.
                             We need them all for testing. Let's go!!!""",
+            title="Greatest book",
             metadata=None,
         )
         return [page1, page2]
@@ -54,11 +60,13 @@ class RAGCoreTestSetup:
             content="""Very useful text. It also contains a new sentence.
 
             And, as we can see here, even a separate paragraph! Life is crazy.""",
+            title=None,
             metadata={"page": 1},
         )
         page2 = Document(
             content="""Another day, another sentence.
                             We need them all for testing. Let's go!!!""",
+            title=None,
             metadata={"page": 2},
         )
         return [page1, page2]
@@ -101,6 +109,7 @@ class RAGCoreTestSetup:
             I mention book before? Another topic is best, the best. This is
             the best book. Not to be confused with the Greatest Book. This, is
             also available now.""",
+            title="Best book",
             metadata={"page": 1, "title": "Best book"},
         )
         return [page3]
@@ -111,6 +120,7 @@ class RAGCoreTestSetup:
             content="""Very useful text. It also contains a new sentence.
 
             And, as we can see here, even a separate paragraph! Life is crazy.""",
+            title="Greatest book",
             metadata={"page": 1, "title": "Greatest book"},
         )
 


### PR DESCRIPTION
New `query` response object `QueryResponse` contains information about the sources on which the response is based on. You can now extract the titles as well as the document chunks from the response.